### PR TITLE
Add sessions endpoint, route, controller and test

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::SessionsController < ApplicationController
+
+  def create
+    user = User.find_by(email: user_info[:email])
+    if user && user.authenticate(user_info[:password])
+      api_key = { api_key: user.api_key }
+      render json: api_key, status: 200
+    else
+      render json: error_response, status: 400
+    end
+  end
+
+  private
+  def user_info
+    params.require(:user).permit(:email, :password)
+  end
+
+  def error_response
+    { error: 'credentials are bad' }
+  end
+
+end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -3,8 +3,7 @@ class Api::V1::SessionsController < ApplicationController
   def create
     user = User.find_by(email: user_info[:email])
     if user && user.authenticate(user_info[:password])
-      api_key = { api_key: user.api_key }
-      render json: api_key, status: 200
+      render json: api_key_response(user), status: 200
     else
       render json: error_response, status: 400
     end
@@ -19,4 +18,7 @@ class Api::V1::SessionsController < ApplicationController
     { error: 'credentials are bad' }
   end
 
+  def api_key_response(user)
+    { api_key: user.api_key }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/forecast', to: 'forecast#index'
       resources :users, only: [:create], defaults: { format: :json }
+      resources :sessions, only: [:create], defaults: { format: :json }
     end
   end
 end

--- a/spec/requests/api/v1/login_user_spec.rb
+++ b/spec/requests/api/v1/login_user_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe 'Login User API', type: :request do
+  it 'logs in a user and returns the users api_key' do
+    User.destroy_all
+    user = User.create!( email: "whatever@example.com", password: "password", password_confirmation: "password")
+    user_api_key = user.api_key
+    req_body = {
+              "email": "whatever@example.com",
+              "password": "password"
+            }
+    post '/api/v1/sessions', params: {user: req_body}
+
+
+    api_key_response = JSON.parse(response.body)
+
+    expect(api_key_response).to be_a Hash
+    expect(api_key_response).to have_key 'api_key'
+    expect(api_key_response['api_key']).to eq user_api_key
+    expect(response.status).to eq 200
+  end
+
+  it 'does not log in a user with incomplete info' do
+    User.destroy_all
+    user = User.create!( email: "whatever@example.com", password: "password", password_confirmation: "password")
+    user_api_key = user.api_key
+    req_body = {
+              "email": "whatever@example.com",
+            }
+    post '/api/v1/sessions', params: {user: req_body}
+
+    error_response = JSON.parse(response.body)
+    expected_error = {"error"=>"credentials are bad"}
+    expect(error_response).to eq expected_error
+    expect(response.status).to eq 400
+  end
+end


### PR DESCRIPTION
Per the Login requirement of sweater weather:
- user can post to '/api/v1/sessions' with user email and password
- response is a hash of the api_key if successful
- response is a hash of error if unsuccessful